### PR TITLE
Use pre-build script to generate version.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "node": ">=18.0.0"
     },
     "scripts": {
+        "prebuild": "node scripts/generate-version.js",
         "build": "tsc",
         "start": "node dist/index.js",
         "dev": "tsx src/index.ts",

--- a/scripts/generate-version.js
+++ b/scripts/generate-version.js
@@ -1,0 +1,19 @@
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+// Get the directory name in ESM
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Read package.json from the parent folder
+const packageJson = JSON.parse(fs.readFileSync(resolve(__dirname, '../package.json'), 'utf8'));
+
+// Create a version file that simply exports the version as a constant
+const versionFileContent = `// Auto-generated file, do not edit
+export const version = '${packageJson.version}';
+`;
+
+// Write to your source directory
+fs.writeFileSync(resolve(__dirname, '../src/utils/version.ts'), versionFileContent);
+console.log(`Generated version file with version ${packageJson.version}`);

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,9 +1,2 @@
-// Read package.json version at runtime instead of import
-import { readFileSync } from 'fs';
-import { join } from 'path';
-import { fileURLToPath } from 'url';
-
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
-const packageJson = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf8'));
-
-export const version = packageJson.version as string;
+// Auto-generated file, do not edit
+export const version = '1.2.1';


### PR DESCRIPTION
The current version.ts uses the Node runtime. In some environments, for e.g Cloudflare Workers runtime, the `fs` module is not available. 

This PR uses a prebuild script to generate version.ts, to avoid importing `fs` at runtime.
