### PR TITLE
Using MCPServer instead of Server and updated handlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.2.1",
             "license": "MIT",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "^1.0.0",
+                "@modelcontextprotocol/sdk": "^1.1.1",
                 "uuid": "^9.0.1",
                 "zod": "^3.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "homepage": "https://github.com/stanislavlysenko0912/todoist-mcp-server#readme",
     "license": "MIT",
     "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.1.1",
         "uuid": "^9.0.1",
         "zod": "^3.0.0"
     },

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -1,15 +1,15 @@
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { TodoistClient } from "./utils/TodoistClient.js";
-import { config, version } from "./utils/helpers.js";
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { TodoistClient } from './utils/TodoistClient.js';
+import { config, version } from './utils/helpers.js';
 
 export const todoistApi = new TodoistClient(config.API_KEY);
 
 export const server = new McpServer(
     {
         name: 'todoist-mcp',
-        version
+        version,
     },
     {
-        instructions: "You this server to interact with Todoist API"
+        instructions: 'Use this server to interact with Todoist API',
     }
 );

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -1,0 +1,12 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { TodoistClient } from "./utils/TodoistClient.js";
+import { config, version } from "./utils/helpers.js";
+
+export const todoistApi = new TodoistClient(config.API_KEY);
+
+export const server = new McpServer(
+    {
+        name: 'todoist-mcp',
+        version,
+    }
+);

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -7,6 +7,9 @@ export const todoistApi = new TodoistClient(config.API_KEY);
 export const server = new McpServer(
     {
         name: 'todoist-mcp',
-        version,
+        version
+    },
+    {
+        instructions: "You this server to interact with Todoist API"
     }
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,75 +1,10 @@
 #!/usr/bin/env node
 
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { server } from './clients.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import {
-    CallToolRequestSchema,
-    GetPromptRequestSchema,
-    ListPromptsRequestSchema,
-    ListToolsRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
-import { ALL_PROMPT_HANDLERS, ALL_PROMPTS } from './prompts.js';
-import { ALL_HANDLERS, ALL_TOOLS } from './tools.js';
 import { config, log } from './utils/helpers.js';
-import { version } from './utils/version.js';
 
-const server = new Server(
-    {
-        name: 'todoist-mcp',
-        version,
-    },
-    { capabilities: { tools: {}, prompts: {} } }
-);
-
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-    return { tools: ALL_TOOLS };
-});
-
-server.setRequestHandler(ListPromptsRequestSchema, async () => {
-    return { prompts: ALL_PROMPTS };
-});
-
-server.setRequestHandler(CallToolRequestSchema, async request => {
-    const toolName = request.params.name;
-
-    log('Tool call: ', toolName);
-
-    try {
-        const handler = ALL_HANDLERS[toolName];
-
-        if (!handler) {
-            throw new Error(`Unknown tool: ${toolName}`);
-        }
-
-        return await handler(request);
-    } catch (error) {
-        log('Error handling tool call:', error);
-
-        return {
-            content: [
-                {
-                    type: 'text',
-                    text: `Error: ${error instanceof Error ? error.message : String(error)}`,
-                },
-            ],
-            isError: true,
-        };
-    }
-});
-
-server.setRequestHandler(GetPromptRequestSchema, async request => {
-    const promptName = request.params.name;
-
-    log('Prompt call: ', promptName);
-
-    const handler = ALL_PROMPT_HANDLERS[promptName];
-
-    if (!handler) {
-        throw new Error(`Unknown prompt: ${promptName}`);
-    }
-
-    return await handler(request);
-});
+import './prompts.js';
 
 export async function main() {
     if (!config.API_KEY || config.API_KEY.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
-import { server } from './clients.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { server } from './clients.js';
 import { config, log } from './utils/helpers.js';
 
 import './prompts.js';
+import './tools.js';
 
 export async function main() {
     if (!config.API_KEY || config.API_KEY.length === 0) {

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,7 +1,1 @@
-import { PROJECT_LIST_PROMPT, PROJECT_LIST_RPOMPT_HANDLER } from './prompts/projects.js';
-
-export const ALL_PROMPTS = [PROJECT_LIST_PROMPT];
-
-export const ALL_PROMPT_HANDLERS = {
-    ...PROJECT_LIST_RPOMPT_HANDLER,
-};
+import './prompts/projects.js';

--- a/src/prompts/projects.ts
+++ b/src/prompts/projects.ts
@@ -1,5 +1,4 @@
 import { server, todoistApi } from "../clients.js";
-import { PromptHandlers } from '../utils/types.js';
 
 type SectionType = {
     id: string | number;

--- a/src/prompts/projects.ts
+++ b/src/prompts/projects.ts
@@ -1,4 +1,4 @@
-import { todoistApi } from '../utils/helpers.js';
+import { server, todoistApi } from "../clients.js";
 import { PromptHandlers } from '../utils/types.js';
 
 type SectionType = {
@@ -28,8 +28,7 @@ export const PROJECT_LIST_PROMPT = {
     description: 'List of projects',
 };
 
-export const PROJECT_LIST_RPOMPT_HANDLER: PromptHandlers = {
-    projects_list: async () => {
+server.prompt(PROJECT_LIST_PROMPT.name, {}, async () => {
         const [projects, sections] = await Promise.all([
             todoistApi.get('/projects'),
             todoistApi.get('/sections'),
@@ -47,21 +46,21 @@ export const PROJECT_LIST_RPOMPT_HANDLER: PromptHandlers = {
         const markdownParts = [
             '# Todoist Projects Overview',
             '',
-            `*Total Projects: ${projects.length}*`,
+            `*Total Projects: ${ projects.length }*`,
             '',
         ];
 
         projects.forEach((project: Project) => {
             const projectSections = sectionsByProject[project.id] || [];
 
-            markdownParts.push(`## ${project.name}`);
+            markdownParts.push(`## ${ project.name }`);
 
             markdownParts.push('| Property | Value |');
             markdownParts.push('| -------- | ----- |');
-            markdownParts.push(`| ID | \`${project.id}\` |`);
-            markdownParts.push(`| Order | ${project.order} |`);
-            markdownParts.push(`| Parent ID | ${project.parent_id || 'None'} |`);
-            markdownParts.push(`| View Style | ${project.view_style} |`);
+            markdownParts.push(`| ID | \`${ project.id }\` |`);
+            markdownParts.push(`| Order | ${ project.order } |`);
+            markdownParts.push(`| Parent ID | ${ project.parent_id || 'None' } |`);
+            markdownParts.push(`| View Style | ${ project.view_style } |`);
 
             if (project.is_inbox_project) markdownParts.push(`| Status | Inbox Project |`);
             if (project.is_shared) markdownParts.push(`| Sharing | Shared |`);
@@ -71,19 +70,19 @@ export const PROJECT_LIST_RPOMPT_HANDLER: PromptHandlers = {
             if (project.description?.length > 0) {
                 const truncatedDescription =
                     project.description.length > 100
-                        ? `${project.description.substring(0, 100).split(' ').slice(0, -1).join(' ')}...`
+                        ? `${ project.description.substring(0, 100).split(' ').slice(0, -1).join(' ') }...`
                         : project.description;
 
-                markdownParts.push(`| Description | ${truncatedDescription} |`);
+                markdownParts.push(`| Description | ${ truncatedDescription } |`);
             }
 
             markdownParts.push('');
 
             if (projectSections.length > 0) {
-                markdownParts.push(`### Sections (${projectSections.length})`);
+                markdownParts.push(`### Sections (${ projectSections.length })`);
 
                 projectSections.forEach(section => {
-                    markdownParts.push(`- **${section.name}** (ID: \`${section.id}\`)`);
+                    markdownParts.push(`- **${ section.name }** (ID: \`${ section.id }\`)`);
                 });
             } else {
                 markdownParts.push('### Sections\n*No sections found*');
@@ -103,5 +102,5 @@ export const PROJECT_LIST_RPOMPT_HANDLER: PromptHandlers = {
                 },
             ],
         };
-    },
-};
+    }
+);

--- a/src/prompts/projects.ts
+++ b/src/prompts/projects.ts
@@ -1,4 +1,4 @@
-import { server, todoistApi } from "../clients.js";
+import { server, todoistApi } from '../clients.js';
 
 type SectionType = {
     id: string | number;
@@ -28,78 +28,77 @@ export const PROJECT_LIST_PROMPT = {
 };
 
 server.prompt(PROJECT_LIST_PROMPT.name, {}, async () => {
-        const [projects, sections] = await Promise.all([
-            todoistApi.get('/projects'),
-            todoistApi.get('/sections'),
-        ]);
+    const [projects, sections] = await Promise.all([
+        todoistApi.get('/projects'),
+        todoistApi.get('/sections'),
+    ]);
 
-        const sectionsByProject: SectionsByProjectType = sections.reduce(
-            (acc: SectionsByProjectType, section: SectionType) => {
-                acc[section.project_id] = acc[section.project_id] || [];
-                acc[section.project_id].push(section);
-                return acc;
-            },
-            {}
-        );
+    const sectionsByProject: SectionsByProjectType = sections.reduce(
+        (acc: SectionsByProjectType, section: SectionType) => {
+            acc[section.project_id] = acc[section.project_id] || [];
+            acc[section.project_id].push(section);
+            return acc;
+        },
+        {}
+    );
 
-        const markdownParts = [
-            '# Todoist Projects Overview',
-            '',
-            `*Total Projects: ${ projects.length }*`,
-            '',
-        ];
+    const markdownParts = [
+        '# Todoist Projects Overview',
+        '',
+        `*Total Projects: ${projects.length}*`,
+        '',
+    ];
 
-        projects.forEach((project: Project) => {
-            const projectSections = sectionsByProject[project.id] || [];
+    projects.forEach((project: Project) => {
+        const projectSections = sectionsByProject[project.id] || [];
 
-            markdownParts.push(`## ${ project.name }`);
+        markdownParts.push(`## ${project.name}`);
 
-            markdownParts.push('| Property | Value |');
-            markdownParts.push('| -------- | ----- |');
-            markdownParts.push(`| ID | \`${ project.id }\` |`);
-            markdownParts.push(`| Order | ${ project.order } |`);
-            markdownParts.push(`| Parent ID | ${ project.parent_id || 'None' } |`);
-            markdownParts.push(`| View Style | ${ project.view_style } |`);
+        markdownParts.push('| Property | Value |');
+        markdownParts.push('| -------- | ----- |');
+        markdownParts.push(`| ID | \`${project.id}\` |`);
+        markdownParts.push(`| Order | ${project.order} |`);
+        markdownParts.push(`| Parent ID | ${project.parent_id || 'None'} |`);
+        markdownParts.push(`| View Style | ${project.view_style} |`);
 
-            if (project.is_inbox_project) markdownParts.push(`| Status | Inbox Project |`);
-            if (project.is_shared) markdownParts.push(`| Sharing | Shared |`);
+        if (project.is_inbox_project) markdownParts.push(`| Status | Inbox Project |`);
+        if (project.is_shared) markdownParts.push(`| Sharing | Shared |`);
 
-            // if (project.url) markdownParts.push(`| URL | [Open in Todoist](${project.url}) |`);
+        // if (project.url) markdownParts.push(`| URL | [Open in Todoist](${project.url}) |`);
 
-            if (project.description?.length > 0) {
-                const truncatedDescription =
-                    project.description.length > 100
-                        ? `${ project.description.substring(0, 100).split(' ').slice(0, -1).join(' ') }...`
-                        : project.description;
+        if (project.description?.length > 0) {
+            const truncatedDescription =
+                project.description.length > 100
+                    ? `${project.description.substring(0, 100).split(' ').slice(0, -1).join(' ')}...`
+                    : project.description;
 
-                markdownParts.push(`| Description | ${ truncatedDescription } |`);
-            }
+            markdownParts.push(`| Description | ${truncatedDescription} |`);
+        }
 
-            markdownParts.push('');
+        markdownParts.push('');
 
-            if (projectSections.length > 0) {
-                markdownParts.push(`### Sections (${ projectSections.length })`);
+        if (projectSections.length > 0) {
+            markdownParts.push(`### Sections (${projectSections.length})`);
 
-                projectSections.forEach(section => {
-                    markdownParts.push(`- **${ section.name }** (ID: \`${ section.id }\`)`);
-                });
-            } else {
-                markdownParts.push('### Sections\n*No sections found*');
-            }
+            projectSections.forEach(section => {
+                markdownParts.push(`- **${section.name}** (ID: \`${section.id}\`)`);
+            });
+        } else {
+            markdownParts.push('### Sections\n*No sections found*');
+        }
 
-            markdownParts.push('');
-        });
+        markdownParts.push('');
+    });
 
-        return {
-            messages: [
-                {
-                    role: 'user',
-                    content: {
-                        type: 'text',
-                        text: markdownParts.join('\n'),
-                    },
+    return {
+        messages: [
+            {
+                role: 'user',
+                content: {
+                    type: 'text',
+                    text: markdownParts.join('\n'),
                 },
-            ],
-        };
-    }
-);
+            },
+        ],
+    };
+});

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,24 +1,6 @@
-import { TASKS_TOOLS, TASK_HANDLERS } from './tools/tasks.js';
-import { PROJECT_TOOLS, PROJECT_HANDLERS } from './tools/projects.js';
-import { SECTION_TOOLS, SECTION_HANDLERS } from './tools/sections.js';
-import { UTILS_TOOLS, UTILS_HANDLERS } from './tools/utils.js';
-import { COMMENTS_TOOLS, COMMENT_HANDLERS } from './tools/comments.js';
-import { LABELS_TOOLS, LABEL_HANDLERS } from './tools/labels.js';
-
-export const ALL_TOOLS = [
-    ...TASKS_TOOLS,
-    ...PROJECT_TOOLS,
-    ...SECTION_TOOLS,
-    ...COMMENTS_TOOLS,
-    ...LABELS_TOOLS,
-    ...UTILS_TOOLS,
-];
-
-export const ALL_HANDLERS = {
-    ...TASK_HANDLERS,
-    ...PROJECT_HANDLERS,
-    ...SECTION_HANDLERS,
-    ...COMMENT_HANDLERS,
-    ...LABEL_HANDLERS,
-    ...UTILS_HANDLERS,
-};
+import './tools/comments.js';
+import './tools/labels.js';
+import './tools/projects.js';
+import './tools/sections.js';
+import './tools/tasks.js';
+import './tools/utils.js';

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -1,198 +1,64 @@
-import { Tool } from '@modelcontextprotocol/sdk/types.js';
-import { ToolHandlers } from '../utils/types.js';
-import z from 'zod';
+import { z } from 'zod';
 import { createApiHandler, createBatchApiHandler } from '../utils/handlers.js';
 
-export const COMMENTS_TOOLS: Tool[] = [
-    {
-        name: 'get_comments_list',
-        description: 'Get all comments from Todoist',
-        inputSchema: {
-            type: 'object',
-            required: [],
-            properties: {
-                project_id: {
-                    type: 'string',
-                    description: 'ID of the project used to filter comments',
-                },
-                task_id: {
-                    type: 'string',
-                    description: 'ID of the task used to filter comments',
-                },
-            },
-            anyOf: [{ required: ['project_id'] }, { required: ['task_id'] }],
-        },
+createApiHandler({
+    name: 'get_comments_list',
+    description: 'Get comments list from Todoist',
+    schemaShape: {
+        project_id: z.string().optional(),
+        task_id: z.string().optional(),
     },
-    {
-        name: 'create_comments',
-        description: 'Create new comments in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of comment objects to create',
-                    items: {
-                        type: 'object',
-                        required: ['content'],
-                        properties: {
-                            task_id: {
-                                type: 'string',
-                                description: "Comment's task ID (for task comments)",
-                            },
-                            project_id: {
-                                type: 'string',
-                                description: "Comment's project ID (for project comments)",
-                            },
-                            content: {
-                                type: 'string',
-                                description: 'Comment markdown-formatted text and hyperlinks',
-                            },
-                            // attachment: {
-                            //     type: "object",
-                            //     description: 'Object for attachment object'
-                            // }
-                        },
-                        anyOf: [{ required: ['task_id'] }, { required: ['project_id'] }],
-                    },
-                },
-            },
-        },
+    method: 'GET',
+    path: '/comments',
+});
+
+createBatchApiHandler({
+    name: 'create_comments',
+    description: 'Create new comments in Todoist',
+    itemSchema: {
+        task_id: z.string().optional(),
+        project_id: z.string().optional(),
+        content: z.string(),
+        // attachment: z.object({}).optional(),
     },
-    {
-        name: 'get_comments',
-        description: 'Get comments from Todoist by ID',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of comment identifiers to retrieve',
-                    items: {
-                        type: 'object',
-                        required: ['id'],
-                        properties: {
-                            id: {
-                                type: 'string',
-                                description: 'ID of the comment to retrieve',
-                            },
-                        },
-                    },
-                },
-            },
-        },
+    method: 'POST',
+    path: '/comments',
+    mode: 'create',
+});
+
+createBatchApiHandler({
+    name: 'get_comments',
+    description: 'Get comments from Todoist by ID',
+    itemSchema: {
+        id: z.string(),
     },
-    {
-        name: 'update_comments',
-        description: 'Update comments in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of comment objects to update',
-                    items: {
-                        type: 'object',
-                        required: ['id', 'content'],
-                        properties: {
-                            id: {
-                                type: 'string',
-                                description: 'ID of the comment to update',
-                            },
-                            content: {
-                                type: 'string',
-                                description: 'New content, markdown-formatted text and hyperlinks',
-                            },
-                        },
-                    },
-                },
-            },
-        },
+    method: 'GET',
+    path: '/comments/{id}',
+    mode: 'read',
+    idField: 'id',
+});
+
+createBatchApiHandler({
+    name: 'update_comments',
+    description: 'Update comments in Todoist',
+    itemSchema: {
+        id: z.string(),
+        content: z.string(),
     },
-    {
-        name: 'delete_comments',
-        description: 'Delete comments in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of comments to delete',
-                    items: {
-                        type: 'object',
-                        required: ['id'],
-                        properties: {
-                            id: {
-                                type: 'string',
-                                description: 'ID of the comment to delete',
-                            },
-                        },
-                    },
-                },
-            },
-        },
+    method: 'POST',
+    path: '/comments/{id}',
+    mode: 'update',
+    idField: 'id',
+});
+
+createBatchApiHandler({
+    name: 'delete_comments',
+    description: 'Delete comments in Todoist',
+    itemSchema: {
+        id: z.string(),
     },
-];
-
-export const COMMENT_HANDLERS: ToolHandlers = {
-    get_comments_list: createApiHandler({
-        schemaShape: {
-            project_id: z.string().optional(),
-            task_id: z.string().optional(),
-        },
-        method: 'GET',
-        path: '/comments',
-        errorPrefix: 'Failed to get comments',
-    }),
-
-    create_comments: createBatchApiHandler({
-        itemSchema: {
-            task_id: z.string().optional(),
-            project_id: z.string().optional(),
-            content: z.string(),
-            // attachment: z.object({}).optional(),
-        },
-        method: 'POST',
-        path: '/comments',
-        errorPrefix: 'Failed to create comments',
-        mode: 'create',
-    }),
-
-    get_comments: createBatchApiHandler({
-        itemSchema: {
-            id: z.string(),
-        },
-        method: 'GET',
-        path: '/comments/{id}',
-        errorPrefix: 'Failed to get comments',
-        mode: 'read',
-        idField: 'id',
-    }),
-
-    update_comments: createBatchApiHandler({
-        itemSchema: {
-            id: z.string(),
-            content: z.string(),
-        },
-        method: 'POST',
-        path: '/comments/{id}',
-        errorPrefix: 'Failed to update comments',
-        mode: 'update',
-        idField: 'id',
-    }),
-
-    delete_comments: createBatchApiHandler({
-        itemSchema: {
-            id: z.string(),
-        },
-        method: 'DELETE',
-        path: '/comments/{id}',
-        idField: 'id',
-        errorPrefix: 'Failed to delete comments',
-        mode: 'delete',
-    }),
-};
+    method: 'DELETE',
+    path: '/comments/{id}',
+    idField: 'id',
+    mode: 'delete',
+});

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -5,8 +5,8 @@ createApiHandler({
     name: 'get_comments_list',
     description: 'Get comments list from Todoist',
     schemaShape: {
-        project_id: z.string().optional(),
-        task_id: z.string().optional(),
+        project_id: z.string().optional().describe('Filter by project'),
+        task_id: z.string().optional().describe('Filter by task'),
     },
     method: 'GET',
     path: '/comments',
@@ -18,7 +18,7 @@ createBatchApiHandler({
     itemSchema: {
         task_id: z.string().optional(),
         project_id: z.string().optional(),
-        content: z.string(),
+        content: z.string().describe('Markdown-formatted text and hyperlinks'),
         // attachment: z.object({}).optional(),
     },
     method: 'POST',
@@ -43,7 +43,7 @@ createBatchApiHandler({
     description: 'Update comments in Todoist',
     itemSchema: {
         id: z.string(),
-        content: z.string(),
+        content: z.string().describe('Markdown-formatted text and hyperlinks'),
     },
     method: 'POST',
     path: '/comments/{id}',

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -40,16 +40,6 @@ createBatchApiHandler({
     nameField: 'name',
     findByName: (name, items) =>
         items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
-    validateItem: item => {
-        if (!item.name && !item.id) {
-            return {
-                valid: false,
-                error: 'Either name or id must be provided',
-            };
-        }
-
-        return { valid: true };
-    },
 });
 
 createBatchApiHandler({
@@ -85,16 +75,6 @@ createBatchApiHandler({
     mode: 'delete',
     findByName: (name, items) =>
         items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
-    validateItem: item => {
-        if (!item.name && !item.id) {
-            return {
-                valid: false,
-                error: 'Either name or id must be provided',
-            };
-        }
-
-        return { valid: true };
-    },
 });
 
 createApiHandler({

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -15,7 +15,10 @@ createBatchApiHandler({
     itemSchema: {
         name: z.string(),
         order: z.number().int().optional(),
-        color: z.string().optional(),
+        color: z
+            .string()
+            .optional()
+            .describe('Refer to the name column in the `utils_get_colors` tool for more info'),
         is_favorite: z.boolean().optional(),
     },
     method: 'POST',
@@ -27,8 +30,8 @@ createBatchApiHandler({
     name: 'get_labels',
     description: 'Get a personal label from Todoist',
     itemSchema: {
-        id: z.string().optional(),
-        name: z.string().optional(),
+        id: z.string().optional().describe('ID of the label to retrieve (preferred over name)'),
+        name: z.string().optional().describe('Name of the label to retrieve'),
     },
     method: 'GET',
     path: '/labels/{id}',
@@ -37,6 +40,16 @@ createBatchApiHandler({
     nameField: 'name',
     findByName: (name, items) =>
         items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
+    validateItem: item => {
+        if (!item.name && !item.id) {
+            return {
+                valid: false,
+                error: 'Either name or id must be provided',
+            };
+        }
+
+        return { valid: true };
+    },
 });
 
 createBatchApiHandler({
@@ -46,7 +59,10 @@ createBatchApiHandler({
         id: z.string(),
         name: z.string().optional(),
         order: z.number().int().optional(),
-        color: z.string().optional(),
+        color: z
+            .string()
+            .optional()
+            .describe('Refer to the name column in the `utils_get_colors` tool for more info'),
         is_favorite: z.boolean().optional(),
     },
     method: 'POST',
@@ -59,8 +75,8 @@ createBatchApiHandler({
     name: 'delete_labels',
     description: 'Delete a personal label in Todoist',
     itemSchema: {
-        id: z.string().optional(),
-        name: z.string().optional(),
+        id: z.string().optional().describe('ID of the label to delete (preferred over name)'),
+        name: z.string().optional().describe('Name of the label to delete'),
     },
     method: 'DELETE',
     path: '/labels/{id}',
@@ -69,6 +85,16 @@ createBatchApiHandler({
     mode: 'delete',
     findByName: (name, items) =>
         items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
+    validateItem: item => {
+        if (!item.name && !item.id) {
+            return {
+                valid: false,
+                error: 'Either name or id must be provided',
+            };
+        }
+
+        return { valid: true };
+    },
 });
 
 createApiHandler({

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -1,311 +1,103 @@
-import { Tool } from '@modelcontextprotocol/sdk/types.js';
-import { ToolHandlers } from '../utils/types.js';
-import z from 'zod';
+import { z } from 'zod';
 import { createApiHandler, createBatchApiHandler } from '../utils/handlers.js';
 
-export const LABELS_TOOLS: Tool[] = [
-    {
-        name: 'get_labels_list',
-        description: 'Get all personal labels from Todoist',
-        inputSchema: {
-            type: 'object',
-            required: [],
-        },
-    },
-    {
-        name: 'create_labels',
-        description: 'Create a new personal labels in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of labels objects to create',
-                    items: {
-                        type: 'object',
-                        required: ['name'],
-                        properties: {
-                            name: {
-                                type: 'string',
-                                description: 'Name of the label',
-                            },
-                            order: {
-                                type: 'integer',
-                                description: 'Label order',
-                            },
-                            color: {
-                                type: 'string',
-                                description:
-                                    'The color of the label icon. Refer to the name column in the `utils_get_colors` tool for more info',
-                            },
-                            is_favorite: {
-                                type: 'boolean',
-                                description:
-                                    'Whether the label is a favorite (a true or false value)',
-                            },
-                        },
-                    },
-                },
-            },
-        },
-    },
-    {
-        name: 'get_labels',
-        description: 'Get a personal labels from Todoist by ID',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of label identifiers to retrieve',
-                    items: {
-                        type: 'object',
-                        properties: {
-                            id: {
-                                type: 'string',
-                                description: 'ID of the label to retrieve (preferred over name)',
-                            },
-                            name: {
-                                type: 'string',
-                                description: 'Name of the label to retrieve',
-                            },
-                        },
-                        anyOf: [{ required: ['id'] }, { required: ['name'] }],
-                    },
-                },
-            },
-        },
-    },
-    {
-        name: 'update_labels',
-        description: 'Update a personal label in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description:
-                        'Array of labels objects to update, need to provide at least one of the following: id, name',
-                    additionalDescription:
-                        'At least one of name, order, color or is_favorite fields must be provided besides the required id',
-                    items: {
-                        type: 'object',
-                        required: ['id'],
-                        properties: {
-                            id: {
-                                type: 'string',
-                                description: 'ID of the label to update',
-                            },
-                            name: {
-                                type: 'string',
-                                description: 'New name of the label',
-                            },
-                            order: {
-                                type: 'integer',
-                                description:
-                                    'Number that is used by clients to sort list of labels',
-                            },
-                            color: {
-                                type: 'string',
-                                description:
-                                    'The color of the label icon. Refer to the name column in the Colors guide for more info',
-                            },
-                            is_favorite: {
-                                type: 'boolean',
-                                description:
-                                    'Whether the label is a favorite (a true or false value)',
-                            },
-                        },
-                    },
-                },
-            },
-        },
-    },
-    {
-        name: 'delete_labels',
-        description: 'Delete a personal labels in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of labels to delete',
-                    items: {
-                        type: 'object',
-                        properties: {
-                            id: {
-                                type: 'string',
-                                description: 'ID of the label to delete (preferred over name)',
-                            },
-                            name: {
-                                type: 'string',
-                                description: 'Name of the label to delete',
-                            },
-                        },
-                        anyOf: [{ required: ['id'] }, { required: ['name'] }],
-                    },
-                },
-            },
-        },
-    },
-    {
-        name: 'get_shared_labels',
-        description: 'Get all shared labels from Todoist',
-        inputSchema: {
-            type: 'object',
-            required: [],
-            properties: {},
-        },
-    },
-    {
-        name: 'rename_shared_labels',
-        description: 'Rename a shared labels in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of shared labels objects to rename',
-                    items: {
-                        type: 'object',
-                        required: ['name', 'new_name'],
-                        properties: {
-                            name: {
-                                type: 'string',
-                                description: 'The name of the existing label to rename',
-                            },
-                            new_name: {
-                                type: 'string',
-                                description: 'The new name for the label',
-                            },
-                        },
-                    },
-                },
-            },
-        },
-    },
-    {
-        name: 'remove_shared_labels',
-        description: 'Remove a shared labels in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of labels objects to remove',
-                    items: {
-                        type: 'object',
-                        required: ['name'],
-                        properties: {
-                            name: {
-                                type: 'string',
-                                description: 'The name of the label to remove',
-                            },
-                        },
-                    },
-                },
-            },
-        },
-    },
-];
+createApiHandler({
+    name: 'get_labels_list',
+    description: 'Get all personal labels from Todoist',
+    schemaShape: {},
+    method: 'GET',
+    path: '/labels',
+});
 
-export const LABEL_HANDLERS: ToolHandlers = {
-    get_labels_list: createApiHandler({
-        schemaShape: {},
-        method: 'GET',
-        path: '/labels',
-        errorPrefix: 'Failed to get labels',
-    }),
+createBatchApiHandler({
+    name: 'create_labels',
+    description: 'Create a new personal labels in Todoist',
+    itemSchema: {
+        name: z.string(),
+        order: z.number().int().optional(),
+        color: z.string().optional(),
+        is_favorite: z.boolean().optional(),
+    },
+    method: 'POST',
+    path: '/labels',
+    mode: 'create',
+});
 
-    create_labels: createBatchApiHandler({
-        itemSchema: {
-            name: z.string(),
-            order: z.number().int().optional(),
-            color: z.string().optional(),
-            is_favorite: z.boolean().optional(),
-        },
-        method: 'POST',
-        path: '/labels',
-        errorPrefix: 'Failed to create labels',
-        mode: 'create',
-    }),
+createBatchApiHandler({
+    name: 'get_labels',
+    description: 'Get a personal label from Todoist',
+    itemSchema: {
+        id: z.string().optional(),
+        name: z.string().optional(),
+    },
+    method: 'GET',
+    path: '/labels/{id}',
+    mode: 'read',
+    idField: 'id',
+    nameField: 'name',
+    findByName: (name, items) =>
+        items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
+});
 
-    get_labels: createBatchApiHandler({
-        itemSchema: {
-            id: z.string().optional(),
-            name: z.string().optional(),
-        },
-        method: 'GET',
-        path: '/labels/{id}',
-        errorPrefix: 'Failed to get labels',
-        mode: 'read',
-        idField: 'id',
-        nameField: 'name',
-        findByName: (name, items) =>
-            items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
-    }),
+createBatchApiHandler({
+    name: 'update_labels',
+    description: 'Update a personal label in Todoist',
+    itemSchema: {
+        id: z.string(),
+        name: z.string().optional(),
+        order: z.number().int().optional(),
+        color: z.string().optional(),
+        is_favorite: z.boolean().optional(),
+    },
+    method: 'POST',
+    path: '/labels/{id}',
+    mode: 'update',
+    idField: 'id',
+});
 
-    update_labels: createBatchApiHandler({
-        itemSchema: {
-            id: z.string(),
-            name: z.string().optional(),
-            order: z.number().int().optional(),
-            color: z.string().optional(),
-            is_favorite: z.boolean().optional(),
-        },
-        method: 'POST',
-        path: '/labels/{id}',
-        errorPrefix: 'Failed to update labels',
-        mode: 'update',
-        idField: 'id',
-    }),
+createBatchApiHandler({
+    name: 'delete_labels',
+    description: 'Delete a personal label in Todoist',
+    itemSchema: {
+        id: z.string().optional(),
+        name: z.string().optional(),
+    },
+    method: 'DELETE',
+    path: '/labels/{id}',
+    idField: 'id',
+    nameField: 'name',
+    mode: 'delete',
+    findByName: (name, items) =>
+        items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
+});
 
-    delete_labels: createBatchApiHandler({
-        itemSchema: {
-            id: z.string().optional(),
-            name: z.string().optional(),
-        },
-        method: 'DELETE',
-        path: '/labels/{id}',
-        idField: 'id',
-        nameField: 'name',
-        errorPrefix: 'Failed to delete labels',
-        mode: 'delete',
-        findByName: (name, items) =>
-            items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
-    }),
+createApiHandler({
+    name: 'get_shared_labels',
+    description: 'Get all shared labels from Todoist',
+    schemaShape: {},
+    method: 'GET',
+    path: '/labels/shared',
+});
 
-    get_shared_labels: createApiHandler({
-        schemaShape: {},
-        method: 'GET',
-        path: '/labels/shared',
-        errorPrefix: 'Failed to get shared labels',
-    }),
+createBatchApiHandler({
+    name: 'rename_shared_labels',
+    description: 'Rename a shared label in Todoist',
+    itemSchema: {
+        name: z.string(),
+        new_name: z.string(),
+    },
+    method: 'POST',
+    path: '/labels/shared/rename',
+    mode: 'update',
+});
 
-    rename_shared_labels: createBatchApiHandler({
-        itemSchema: {
-            name: z.string(),
-            new_name: z.string(),
-        },
-        method: 'POST',
-        path: '/labels/shared/rename',
-        errorPrefix: 'Failed to rename shared labels',
-        mode: 'update',
-    }),
-
-    remove_shared_labels: createBatchApiHandler({
-        itemSchema: {
-            name: z.string(),
-        },
-        method: 'POST',
-        path: '/labels/shared/remove',
-        errorPrefix: 'Failed to remove shared labels',
-        mode: 'delete',
-    }),
-};
+createBatchApiHandler({
+    name: 'remove_shared_labels',
+    description: 'Remove a shared label in Todoist',
+    itemSchema: {
+        name: z.string(),
+    },
+    method: 'POST',
+    path: '/labels/shared/remove',
+    mode: 'delete',
+});

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -1,311 +1,112 @@
-import { Tool } from '@modelcontextprotocol/sdk/types.js';
-import { ToolHandlers } from '../utils/types.js';
-import z from 'zod';
+import { z } from 'zod';
 import {
     createApiHandler,
     createBatchApiHandler,
     createSyncApiHandler,
 } from '../utils/handlers.js';
 
-export const PROJECT_TOOLS: Tool[] = [
-    {
-        name: 'get_projects_list',
-        description: 'Get all projects from Todoist',
-        inputSchema: {
-            type: 'object',
-            required: [],
-        },
-    },
-    {
-        name: 'create_projects',
-        description: 'Create new projects in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of project objects to create',
-                    items: {
-                        type: 'object',
-                        required: ['name'],
-                        properties: {
-                            name: {
-                                type: 'string',
-                                description: 'Name of the project',
-                            },
-                            parent_id: {
-                                type: 'string',
-                                description: 'Parent project ID',
-                            },
-                            color: {
-                                type: 'string',
-                                description:
-                                    'The color of the project icon. Refer to the name column in the Colors guide for more info',
-                            },
-                            is_favorite: {
-                                type: 'boolean',
-                                description:
-                                    'Whether the project is a favorite (a true or false value)',
-                            },
-                            view_style: {
-                                type: 'string',
-                                description:
-                                    'A string value, list default. This determines the way the project is displayed',
-                                enum: ['list', 'board'],
-                            },
-                        },
-                    },
-                },
-            },
-        },
-    },
-    {
-        name: 'get_projects',
-        description: 'Get projects from Todoist by ID',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of project identifiers to retrieve',
-                    items: {
-                        type: 'object',
-                        properties: {
-                            id: {
-                                type: 'string',
-                                description: 'ID of the project to retrieve',
-                            },
-                            name: {
-                                type: 'string',
-                                description: 'Name of the project to retrieve',
-                            },
-                        },
-                        anyOf: [{ required: ['id'] }, { required: ['name'] }],
-                    },
-                },
-            },
-        },
-    },
-    {
-        name: 'update_projects',
-        description: 'Update projects in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of project objects to update',
-                    additionalDescription:
-                        'At least one of name, color, is_favorite or view_style fields must be provided besides the required id',
-                    items: {
-                        type: 'object',
-                        required: ['id'],
-                        properties: {
-                            id: {
-                                type: 'string',
-                                description: 'ID of the project to update',
-                            },
-                            name: {
-                                type: 'string',
-                                description: 'Name of the project',
-                            },
-                            color: {
-                                type: 'string',
-                                description:
-                                    'The color of the project icon. Refer to the name column in the Colors guide for more info',
-                            },
-                            is_favorite: {
-                                type: 'boolean',
-                                description:
-                                    'Whether the project is a favorite (a true or false value)',
-                            },
-                            view_style: {
-                                type: 'string',
-                                description:
-                                    'A string value (either list or board). This determines the way the project is displayed within the Todoist clients',
-                                enum: ['list', 'board'],
-                            },
-                        },
-                    },
-                },
-            },
-        },
-    },
-    {
-        name: 'delete_projects',
-        description: 'Delete projects in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of projects to delete',
-                    items: {
-                        type: 'object',
-                        properties: {
-                            id: {
-                                type: 'string',
-                                description: 'ID of the project to delete (preferred over name)',
-                            },
-                            name: {
-                                type: 'string',
-                                description: 'Name of the project to delete',
-                            },
-                        },
-                        anyOf: [{ required: ['id'] }, { required: ['name'] }],
-                    },
-                },
-            },
-        },
-    },
-    {
-        name: 'get_collaborators',
-        description: 'Get all collaborators for a project in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['id'],
-            properties: {
-                id: {
-                    type: 'string',
-                    description: 'ID of the project to get collaborators for',
-                },
-            },
-        },
-    },
-    {
-        name: 'move_projects',
-        description: 'Move a projects to a different parent in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of projects to move',
-                    items: {
-                        type: 'object',
-                        properties: {
-                            id: {
-                                type: 'string',
-                                description: 'ID of the project to move (preferred over name)',
-                            },
-                            name: {
-                                type: 'string',
-                                description: 'Name of the project to move',
-                            },
-                            parent_id: {
-                                type: 'string',
-                                description:
-                                    'ID of the parent project to move this project under. Use null to move to root level.',
-                            },
-                        },
-                        required: ['parent_id'],
-                        anyOf: [{ required: ['id'] }, { required: ['name'] }],
-                    },
-                },
-            },
-        },
-    },
-];
+createApiHandler({
+    name: 'get_projects_list',
+    description: 'Get all projects from Todoist',
+    schemaShape: {},
+    method: 'GET',
+    path: '/projects',
+});
 
-export const PROJECT_HANDLERS: ToolHandlers = {
-    get_projects_list: createApiHandler({
-        schemaShape: {},
-        method: 'GET',
-        path: '/projects',
-        errorPrefix: 'Failed to get projects',
-    }),
+createBatchApiHandler({
+    name: 'create_projects',
+    description: 'Create new projects in Todoist',
+    itemSchema: {
+        name: z.string(),
+        parent_id: z.string().optional(),
+        color: z.string().optional(),
+        is_favorite: z.boolean().optional(),
+        view_style: z.enum(['list', 'board']).optional(),
+    },
+    method: 'POST',
+    path: '/projects',
+    mode: 'create',
+});
 
-    create_projects: createBatchApiHandler({
-        itemSchema: {
-            name: z.string(),
-            parent_id: z.string().optional(),
-            color: z.string().optional(),
-            is_favorite: z.boolean().optional(),
-            view_style: z.enum(['list', 'board']).optional(),
-        },
-        method: 'POST',
-        path: '/projects',
-        errorPrefix: 'Failed to create projects',
-        mode: 'create',
-    }),
+createBatchApiHandler({
+    name: 'get_projects',
+    description: 'Get projects from Todoist',
+    itemSchema: {
+        id: z.string().optional(),
+        name: z.string().optional(),
+    },
+    method: 'GET',
+    path: '/projects/{id}',
+    mode: 'read',
+    idField: 'id',
+    nameField: 'name',
+    findByName: (name, items) =>
+        items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
+});
 
-    get_projects: createBatchApiHandler({
-        itemSchema: {
-            id: z.string().optional(),
-            name: z.string().optional(),
-        },
-        method: 'GET',
-        path: '/projects/{id}',
-        errorPrefix: 'Failed to get projects',
-        mode: 'read',
-        idField: 'id',
-        nameField: 'name',
-        findByName: (name, items) =>
-            items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
-    }),
+createBatchApiHandler({
+    name: 'update_projects',
+    description: 'Update projects in Todoist',
+    itemSchema: {
+        id: z.string().optional(),
+        name: z.string().optional(),
+        color: z.string().optional(),
+        is_favorite: z.boolean().optional(),
+        view_style: z.enum(['list', 'board']).optional(),
+    },
+    method: 'POST',
+    path: '/projects/{id}',
+    mode: 'update',
+    idField: 'id',
+    nameField: 'name',
+    findByName: (name, items) =>
+        items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
+});
 
-    update_projects: createBatchApiHandler({
-        itemSchema: {
-            id: z.string(),
-            name: z.string().optional(),
-            color: z.string().optional(),
-            is_favorite: z.boolean().optional(),
-            view_style: z.enum(['list', 'board']).optional(),
-        },
-        method: 'POST',
-        path: '/projects/{id}',
-        errorPrefix: 'Failed to update projects',
-        mode: 'update',
-        idField: 'id',
-    }),
+createBatchApiHandler({
+    name: 'delete_projects',
+    description: 'Delete projects from Todoist',
+    itemSchema: {
+        id: z.string().optional(),
+        name: z.string().optional(),
+    },
+    method: 'DELETE',
+    path: '/projects/{id}',
+    mode: 'delete',
+    idField: 'id',
+    nameField: 'name',
+    findByName: (name, items) =>
+        items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
+});
 
-    delete_projects: createBatchApiHandler({
-        itemSchema: {
-            id: z.string().optional(),
-            name: z.string().optional(),
-        },
-        method: 'DELETE',
-        path: '/projects/{id}',
-        idField: 'id',
-        nameField: 'name',
-        errorPrefix: 'Failed to delete projects',
-        mode: 'delete',
-        findByName: (name, items) =>
-            items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
-    }),
+createApiHandler({
+    name: 'get_collaborators',
+    description: 'Get all collaborators for a project in Todoist',
+    schemaShape: {
+        id: z.string(),
+    },
+    method: 'GET',
+    path: '/projects/{id}/collaborators',
+});
 
-    get_collaborators: createApiHandler({
-        schemaShape: {
-            id: z.string(),
-        },
-        method: 'GET',
-        path: '/projects/{id}/collaborators',
-        errorPrefix: 'Failed to get collaborators',
-    }),
-
-    move_projects: createSyncApiHandler({
-        itemSchema: {
-            id: z.string().optional(),
-            name: z.string().optional(),
-            parent_id: z.string().nullable(),
-        },
-        commandType: 'project_move',
-        errorPrefix: 'Failed to move projects',
-        idField: 'id',
-        nameField: 'name',
-        lookupPath: '/projects',
-        findByName: (name, items) =>
-            items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
-        buildCommandArgs: (item, itemId) => {
-            return {
-                id: itemId,
-                parent_id: item.parent_id,
-            };
-        },
-    }),
-};
+createSyncApiHandler({
+    name: 'move_projects',
+    description: 'Move a projects to a different parent in Todoist',
+    itemSchema: {
+        id: z.string().optional(),
+        name: z.string().optional(),
+        parent_id: z.string().nullable(),
+    },
+    commandType: 'project_move',
+    idField: 'id',
+    nameField: 'name',
+    lookupPath: '/projects',
+    findByName: (name, items) =>
+        items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
+    buildCommandArgs: (item, itemId) => {
+        return {
+            id: itemId,
+            parent_id: item.parent_id,
+        };
+    },
+});

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -32,8 +32,8 @@ createBatchApiHandler({
     name: 'get_projects',
     description: 'Get projects from Todoist',
     itemSchema: {
-        id: z.string().optional(),
-        name: z.string().optional(),
+        id: z.string().optional().describe('ID of the project to retrieve (preferred over name)'),
+        name: z.string().optional().describe('Name of the project to retrieve'),
     },
     method: 'GET',
     path: '/projects/{id}',
@@ -42,14 +42,24 @@ createBatchApiHandler({
     nameField: 'name',
     findByName: (name, items) =>
         items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
+    validateItem: item => {
+        if (!item.name && !item.id) {
+            return {
+                valid: false,
+                error: 'Either name or id must be provided',
+            };
+        }
+
+        return { valid: true };
+    },
 });
 
 createBatchApiHandler({
     name: 'update_projects',
     description: 'Update projects in Todoist',
     itemSchema: {
-        id: z.string().optional(),
-        name: z.string().optional(),
+        id: z.string().optional().describe('ID of the project to update (preferred over name)'),
+        name: z.string().optional().describe('Name of the project to update'),
         color: z.string().optional(),
         is_favorite: z.boolean().optional(),
         view_style: z.enum(['list', 'board']).optional(),
@@ -61,14 +71,24 @@ createBatchApiHandler({
     nameField: 'name',
     findByName: (name, items) =>
         items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
+    validateItem: item => {
+        if (!item.name && !item.id) {
+            return {
+                valid: false,
+                error: 'Either name or id must be provided',
+            };
+        }
+
+        return { valid: true };
+    },
 });
 
 createBatchApiHandler({
     name: 'delete_projects',
     description: 'Delete projects from Todoist',
     itemSchema: {
-        id: z.string().optional(),
-        name: z.string().optional(),
+        id: z.string().optional().describe('ID of the project to delete (preferred over name)'),
+        name: z.string().optional().describe('Name of the project to delete'),
     },
     method: 'DELETE',
     path: '/projects/{id}',
@@ -77,6 +97,16 @@ createBatchApiHandler({
     nameField: 'name',
     findByName: (name, items) =>
         items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
+    validateItem: item => {
+        if (!item.name && !item.id) {
+            return {
+                valid: false,
+                error: 'Either name or id must be provided',
+            };
+        }
+
+        return { valid: true };
+    },
 });
 
 createApiHandler({
@@ -93,8 +123,8 @@ createSyncApiHandler({
     name: 'move_projects',
     description: 'Move a projects to a different parent in Todoist',
     itemSchema: {
-        id: z.string().optional(),
-        name: z.string().optional(),
+        id: z.string().optional().describe('ID of the project to move (preferred over name)'),
+        name: z.string().optional().describe('Name of the project to move'),
         parent_id: z.string().nullable(),
     },
     commandType: 'project_move',
@@ -108,5 +138,15 @@ createSyncApiHandler({
             id: itemId,
             parent_id: item.parent_id,
         };
+    },
+    validateItem: item => {
+        if (!item.name && !item.id) {
+            return {
+                valid: false,
+                error: 'Either name or id must be provided',
+            };
+        }
+
+        return { valid: true };
     },
 });

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -42,16 +42,6 @@ createBatchApiHandler({
     nameField: 'name',
     findByName: (name, items) =>
         items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
-    validateItem: item => {
-        if (!item.name && !item.id) {
-            return {
-                valid: false,
-                error: 'Either name or id must be provided',
-            };
-        }
-
-        return { valid: true };
-    },
 });
 
 createBatchApiHandler({
@@ -71,16 +61,6 @@ createBatchApiHandler({
     nameField: 'name',
     findByName: (name, items) =>
         items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
-    validateItem: item => {
-        if (!item.name && !item.id) {
-            return {
-                valid: false,
-                error: 'Either name or id must be provided',
-            };
-        }
-
-        return { valid: true };
-    },
 });
 
 createBatchApiHandler({
@@ -97,16 +77,6 @@ createBatchApiHandler({
     nameField: 'name',
     findByName: (name, items) =>
         items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
-    validateItem: item => {
-        if (!item.name && !item.id) {
-            return {
-                valid: false,
-                error: 'Either name or id must be provided',
-            };
-        }
-
-        return { valid: true };
-    },
 });
 
 createApiHandler({
@@ -138,15 +108,5 @@ createSyncApiHandler({
             id: itemId,
             parent_id: item.parent_id,
         };
-    },
-    validateItem: item => {
-        if (!item.name && !item.id) {
-            return {
-                valid: false,
-                error: 'Either name or id must be provided',
-            };
-        }
-
-        return { valid: true };
     },
 });

--- a/src/tools/sections.ts
+++ b/src/tools/sections.ts
@@ -1,207 +1,70 @@
-import { Tool } from '@modelcontextprotocol/sdk/types.js';
-import { ToolHandlers } from '../utils/types.js';
-import z from 'zod';
+import { z } from 'zod';
 import { createApiHandler, createBatchApiHandler } from '../utils/handlers.js';
 
-export const SECTION_TOOLS: Tool[] = [
-    {
-        name: 'get_sections_list',
-        description: 'Get all sections from Todoist',
-        inputSchema: {
-            type: 'object',
-            required: [],
-            properties: {
-                project_id: {
-                    type: 'string',
-                    description: 'Filter sections by project ID',
-                },
-            },
-        },
+createApiHandler({
+    name: 'get_sections_list',
+    description: 'Get sections list from Todoist',
+    schemaShape: {
+        project_id: z.string().optional(),
     },
-    {
-        name: 'create_sections',
-        description: 'Create new sections in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of section objects to create',
-                    items: {
-                        type: 'object',
-                        required: ['name', 'project_id'],
-                        properties: {
-                            name: {
-                                type: 'string',
-                                description: 'Section name',
-                            },
-                            project_id: {
-                                type: 'string',
-                                description: 'Project ID this section should belong to',
-                            },
-                            order: {
-                                type: 'integer',
-                                description: 'Order among other sections in a project',
-                            },
-                        },
-                    },
-                },
-            },
-        },
+    method: 'GET',
+    path: '/sections',
+});
+
+createBatchApiHandler({
+    name: 'create_sections',
+    description: 'Create new sections in Todoist',
+    itemSchema: {
+        name: z.string(),
+        project_id: z.string(),
+        order: z.number().int().optional(),
     },
-    {
-        name: 'get_sections',
-        description: 'Get sections from Todoist by ID',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of section identifiers to retrieve',
-                    items: {
-                        type: 'object',
-                        properties: {
-                            id: {
-                                type: 'string',
-                                description: 'ID of the section to retrieve (preferred over name)',
-                            },
-                            name: {
-                                type: 'string',
-                                description: 'Name of the section to retrieve',
-                            },
-                        },
-                        anyOf: [{ required: ['id'] }, { required: ['name'] }],
-                    },
-                },
-            },
-        },
+    method: 'POST',
+    path: '/sections',
+    mode: 'create',
+});
+
+createBatchApiHandler({
+    name: 'get_sections',
+    description: 'Get sections from Todoist',
+    itemSchema: {
+        id: z.string().optional(),
+        name: z.string().optional(),
     },
-    {
-        name: 'update_sections',
-        description: 'Update sections in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of section objects to update',
-                    items: {
-                        type: 'object',
-                        required: ['id'],
-                        properties: {
-                            id: {
-                                type: 'string',
-                                description: 'ID of the section to update',
-                            },
-                            name: {
-                                type: 'string',
-                                description: 'New section name',
-                            },
-                            order: {
-                                type: 'integer',
-                                description: 'New order among other sections in a project',
-                            },
-                        },
-                    },
-                },
-            },
-        },
+    method: 'GET',
+    path: '/sections/{id}',
+    mode: 'read',
+    idField: 'id',
+    nameField: 'name',
+    findByName: (name, items) =>
+        items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
+});
+
+createBatchApiHandler({
+    name: 'update_sections',
+    description: 'Update sections in Todoist',
+    itemSchema: {
+        id: z.string(),
+        name: z.string().optional(),
     },
-    {
-        name: 'delete_sections',
-        description: 'Delete sections in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of sections to delete',
-                    items: {
-                        type: 'object',
-                        properties: {
-                            id: {
-                                type: 'string',
-                                description: 'ID of the section to delete (preferred over name)',
-                            },
-                            name: {
-                                type: 'string',
-                                description: 'Name of the section to delete',
-                            },
-                        },
-                        anyOf: [{ required: ['id'] }, { required: ['name'] }],
-                    },
-                },
-            },
-        },
+    method: 'POST',
+    path: '/sections/{id}',
+    mode: 'update',
+    idField: 'id',
+});
+
+createBatchApiHandler({
+    name: 'delete_sections',
+    description: 'Delete sections in Todoist',
+    itemSchema: {
+        id: z.string().optional(),
+        name: z.string().optional(),
     },
-];
-
-export const SECTION_HANDLERS: ToolHandlers = {
-    get_sections_list: createApiHandler({
-        schemaShape: {
-            project_id: z.string().optional(),
-        },
-        method: 'GET',
-        path: '/sections',
-        errorPrefix: 'Failed to get sections',
-    }),
-
-    create_sections: createBatchApiHandler({
-        itemSchema: {
-            name: z.string(),
-            project_id: z.string(),
-            order: z.number().int().optional(),
-        },
-        method: 'POST',
-        path: '/sections',
-        errorPrefix: 'Failed to create sections',
-        mode: 'create',
-    }),
-
-    get_sections: createBatchApiHandler({
-        itemSchema: {
-            id: z.string().optional(),
-            name: z.string().optional(),
-        },
-        method: 'GET',
-        path: '/sections/{id}',
-        errorPrefix: 'Failed to get sections',
-        mode: 'read',
-        idField: 'id',
-        nameField: 'name',
-        findByName: (name, items) =>
-            items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
-    }),
-
-    update_sections: createBatchApiHandler({
-        itemSchema: {
-            id: z.string(),
-            name: z.string().optional(),
-            order: z.number().int().optional(),
-        },
-        method: 'POST',
-        path: '/sections/{id}',
-        errorPrefix: 'Failed to update sections',
-        mode: 'update',
-        idField: 'id',
-    }),
-
-    delete_sections: createBatchApiHandler({
-        itemSchema: {
-            id: z.string().optional(),
-            name: z.string().optional(),
-        },
-        method: 'DELETE',
-        path: '/sections/{id}',
-        idField: 'id',
-        nameField: 'name',
-        errorPrefix: 'Failed to delete sections',
-        mode: 'delete',
-        findByName: (name, items) =>
-            items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
-    }),
-};
+    method: 'DELETE',
+    path: '/sections/{id}',
+    idField: 'id',
+    nameField: 'name',
+    mode: 'delete',
+    findByName: (name, items) =>
+        items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
+});

--- a/src/tools/sections.ts
+++ b/src/tools/sections.ts
@@ -28,8 +28,8 @@ createBatchApiHandler({
     name: 'get_sections',
     description: 'Get sections from Todoist',
     itemSchema: {
-        id: z.string().optional(),
-        name: z.string().optional(),
+        id: z.string().optional().describe('ID of the section to retrieve (preferred over name)'),
+        name: z.string().optional().describe('Name of the section to retrieve'),
     },
     method: 'GET',
     path: '/sections/{id}',
@@ -38,6 +38,16 @@ createBatchApiHandler({
     nameField: 'name',
     findByName: (name, items) =>
         items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
+    validateItem: item => {
+        if (!item.name && !item.id) {
+            return {
+                valid: false,
+                error: 'Either name or id must be provided',
+            };
+        }
+
+        return { valid: true };
+    },
 });
 
 createBatchApiHandler({
@@ -57,8 +67,8 @@ createBatchApiHandler({
     name: 'delete_sections',
     description: 'Delete sections in Todoist',
     itemSchema: {
-        id: z.string().optional(),
-        name: z.string().optional(),
+        id: z.string().optional().describe('ID of the section to delete (preferred over name)'),
+        name: z.string().optional().describe('Name of the section to delete'),
     },
     method: 'DELETE',
     path: '/sections/{id}',
@@ -67,4 +77,14 @@ createBatchApiHandler({
     mode: 'delete',
     findByName: (name, items) =>
         items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
+    validateItem: item => {
+        if (!item.name && !item.id) {
+            return {
+                valid: false,
+                error: 'Either name or id must be provided',
+            };
+        }
+
+        return { valid: true };
+    },
 });

--- a/src/tools/sections.ts
+++ b/src/tools/sections.ts
@@ -38,16 +38,6 @@ createBatchApiHandler({
     nameField: 'name',
     findByName: (name, items) =>
         items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
-    validateItem: item => {
-        if (!item.name && !item.id) {
-            return {
-                valid: false,
-                error: 'Either name or id must be provided',
-            };
-        }
-
-        return { valid: true };
-    },
 });
 
 createBatchApiHandler({
@@ -77,14 +67,4 @@ createBatchApiHandler({
     mode: 'delete',
     findByName: (name, items) =>
         items.find(item => item.name.toLowerCase().includes(name.toLowerCase())),
-    validateItem: item => {
-        if (!item.name && !item.id) {
-            return {
-                valid: false,
-                error: 'Either name or id must be provided',
-            };
-        }
-
-        return { valid: true };
-    },
 });

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -171,7 +171,8 @@ createBatchApiHandler({
 
 createSyncApiHandler({
     name: 'move_tasks',
-    description: 'Move tasks to a different parent or section in Todoist',
+    description:
+        'Move tasks to a different parent or section in Todoist. Exactly one of parent_id, section_id, or project_id must be provided',
     itemSchema: {
         task_id: z.string().optional(),
         task_name: z.string().optional(),

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -102,15 +102,6 @@ createBatchApiHandler({
     nameField: 'task_name',
     findByName: (name, items) =>
         items.find(item => item.content.toLowerCase().includes(name.toLowerCase())),
-    validateItem: item => {
-        if (!item.task_id && !item.task_name) {
-            return {
-                valid: false,
-                error: 'Either task_id or task_name must be provided',
-            };
-        }
-        return { valid: true };
-    },
 });
 
 createBatchApiHandler({
@@ -128,15 +119,6 @@ createBatchApiHandler({
     nameField: 'task_name',
     findByName: (name, items) =>
         items.find(item => item.content.toLowerCase().includes(name.toLowerCase())),
-    validateItem: item => {
-        if (!item.task_id && !item.task_name) {
-            return {
-                valid: false,
-                error: 'Either task_id or task_name must be provided',
-            };
-        }
-        return { valid: true };
-    },
 });
 
 createBatchApiHandler({
@@ -153,15 +135,6 @@ createBatchApiHandler({
     nameField: 'task_name',
     findByName: (name, items) =>
         items.find(item => item.content.toLowerCase().includes(name.toLowerCase())),
-    validateItem: item => {
-        if (!item.task_id && !item.task_name) {
-            return {
-                valid: false,
-                error: 'Either task_id or task_name must be provided',
-            };
-        }
-        return { valid: true };
-    },
 });
 
 createBatchApiHandler({
@@ -178,16 +151,6 @@ createBatchApiHandler({
     nameField: 'task_name',
     findByName: (name, items) =>
         items.find(item => item.content.toLowerCase().includes(name.toLowerCase())),
-    validateItem: item => {
-        if (!item.task_id && !item.task_name) {
-            return {
-                valid: false,
-                error: 'Either task_id or task_name must be provided',
-            };
-        }
-
-        return { valid: true };
-    },
 });
 
 createBatchApiHandler({
@@ -204,16 +167,6 @@ createBatchApiHandler({
     nameField: 'task_name',
     findByName: (name, items) =>
         items.find(item => item.content.toLowerCase().includes(name.toLowerCase())),
-    validateItem: item => {
-        if (!item.task_id && !item.task_name) {
-            return {
-                valid: false,
-                error: 'Either task_id or task_name must be provided',
-            };
-        }
-
-        return { valid: true };
-    },
 });
 
 createSyncApiHandler({

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,6 +1,4 @@
-import { Tool } from '@modelcontextprotocol/sdk/types.js';
-import { ToolHandlers } from '../utils/types.js';
-import z from 'zod';
+import { z } from 'zod';
 import {
     createApiHandler,
     createBatchApiHandler,
@@ -9,520 +7,173 @@ import {
 
 /// Common fields for create and update tasks
 const create_fields = {
-    content: {
-        type: 'string',
-        description: 'Task content. This value may contain markdown-formatted text and hyperlinks',
-    },
-    description: {
-        type: 'string',
-        description:
-            'A description for the task. This value may contain markdown-formatted text and hyperlinks',
-    },
-    labels: {
-        type: 'array',
-        items: {
-            type: 'string',
-        },
-        description:
-            "The task's labels (a list of names that may represent either personal or shared labels)",
-    },
-    priority: {
-        type: 'integer',
-        description: 'Task priority from 1 (normal) to 4 (urgent)',
-        enum: [1, 2, 3, 4],
-    },
-    due_string: {
-        type: 'string',
-        description:
-            'Human defined task due date (ex.: "next Monday", "Tomorrow"). Value is set using local (not UTC) time, if not in english provided, due_lang should be set to the language of the string',
-    },
-    due_date: {
-        type: 'string',
-        description: "Specific date in YYYY-MM-DD format relative to user's timezone",
-    },
-    due_datetime: {
-        type: 'string',
-        description: 'Specific date and time in RFC3339 format in UTC',
-    },
-    due_lang: {
-        type: 'string',
-        description:
-            '2-letter code specifying language in case due_string is not written in English',
-        default: 'en',
-    },
-    assignee_id: {
-        type: 'string',
-        description: 'The responsible user ID (only applies to shared tasks)',
-    },
-    duration: {
-        type: 'integer',
-        description:
-            'A positive (greater than zero) integer for the amount of duration_unit the task will take',
-    },
-    duration_unit: {
-        type: 'string',
-        description:
-            'The unit of time that the duration field represents. Must be either minute or day',
-        enum: ['minute', 'day'],
-    },
+    content: z.string(),
+    description: z.string().optional(),
+    labels: z.array(z.string()).optional(),
+    priority: z.number().int().min(1).max(4).optional(),
+    due_string: z.string().optional(),
+    due_date: z.string().optional(),
+    due_datetime: z.string().optional(),
+    due_lang: z.string().optional(),
+    assignee_id: z.string().optional(),
+    duration: z.number().int().positive().optional(),
+    duration_unit: z.enum(['minute', 'day']).optional(),
 };
 
-export const TASKS_TOOLS: Tool[] = [
-    {
-        name: 'get_tasks_list',
-        description: 'Get tasks list from Todoist',
-        inputSchema: {
-            type: 'object',
-            required: [],
-            properties: {
-                project_id: {
-                    type: 'string',
-                    description: 'Filter tasks by project ID',
-                },
-                section_id: {
-                    type: 'string',
-                    description: 'Filter tasks by section ID',
-                },
-                label: {
-                    type: 'string',
-                    description: 'Filter by label name',
-                },
-                filter: {
-                    type: 'string',
-                    description:
-                        'Natural language english filter like "search: keyword", "today", "date before: +4 hours", "date after: May 5", "no date", "no time", "overdue", "7 days & @waiting", "created before: -365 days", "assigned to: person", "added by: me", "#Project & !assigned", "subtask", "!subtask", "P1 | P2", "today & @email", "@work | @office", "(today | overdue) & #Work", "all & 7 days", "!assigned", "Today & !#Work"',
-                },
-                ids: {
-                    type: 'string',
-                    description:
-                        'A list of the task IDs to retrieve, this should be a comma separated list',
-                },
-                limit: {
-                    type: 'number',
-                    description:
-                        'Maximum number of tasks to return, provided by server not api of todoist',
-                    default: 50,
-                },
-            },
-        },
+createApiHandler({
+    name: 'get_tasks_list',
+    description: 'Get tasks list from Todoist',
+    schemaShape: {
+        project_id: z.string().optional(),
+        section_id: z.string().optional(),
+        label: z.string().optional(),
+        filter: z.string().optional(),
+        ids: z.string().optional(),
+        limit: z.number().optional(),
     },
-    {
-        name: 'create_tasks',
-        description: 'Create tasks in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of tasks to create',
-                    items: {
-                        type: 'object',
-                        required: ['content'],
-                        properties: {
-                            ...create_fields,
-                            project_id: {
-                                type: 'string',
-                                description:
-                                    "Task project ID. If not set, task is put to user's Inbox",
-                            },
-                            section_id: {
-                                type: 'string',
-                                description: 'ID of section to put task into',
-                            },
-                            parent_id: {
-                                type: 'string',
-                                description: 'Parent task ID',
-                            },
-                            order: {
-                                type: 'integer',
-                                description:
-                                    'Non-zero integer value used by clients to sort tasks under the same parent',
-                            },
-                        },
-                    },
-                },
-            },
-        },
+    method: 'GET',
+    path: '/tasks',
+});
+
+createBatchApiHandler({
+    name: 'create_tasks',
+    description: 'Create new tasks in Todoist',
+    itemSchema: {
+        ...create_fields,
+        project_id: z.string().optional(),
+        section_id: z.string().optional(),
+        parent_id: z.string().optional(),
     },
-    {
-        name: 'get_tasks',
-        description: 'Get a tasks from Todoist by ID or name',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of task identifiers to retrieve',
-                    items: {
-                        type: 'object',
-                        properties: {
-                            task_id: {
-                                type: 'string',
-                                description: 'ID of the task to retrieve (preferred)',
-                            },
-                            task_name: {
-                                type: 'string',
-                                description: 'Name of the task to retrieve (if ID not provided)',
-                            },
-                        },
-                        anyOf: [{ required: ['task_id'] }, { required: ['task_name'] }],
-                    },
-                },
-            },
-        },
+    method: 'POST',
+    path: '/tasks',
+    mode: 'create',
+});
+
+createBatchApiHandler({
+    name: 'get_tasks',
+    description: 'Get tasks from Todoist',
+    itemSchema: {
+        task_id: z.string().optional(),
+        task_name: z.string().optional(),
     },
-    {
-        name: 'update_tasks',
-        description: 'Update tasks in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of tasks to update',
-                    items: {
-                        type: 'object',
-                        properties: {
-                            task_id: {
-                                type: 'string',
-                                description: 'ID of the task to update (preferred)',
-                            },
-                            task_name: {
-                                type: 'string',
-                                description: 'Name of the task to update (if ID not provided)',
-                            },
-                            ...create_fields,
-                        },
-                        anyOf: [{ required: ['task_id'] }, { required: ['task_name'] }],
-                    },
-                },
-            },
-        },
+    method: 'GET',
+    path: '/tasks/{id}',
+    mode: 'read',
+    idField: 'task_id',
+    nameField: 'task_name',
+    findByName: (name, items) =>
+        items.find(item => item.content.toLowerCase().includes(name.toLowerCase())),
+});
+
+createBatchApiHandler({
+    name: 'update_tasks',
+    description: 'Update tasks in Todoist',
+    itemSchema: {
+        task_id: z.string().optional(),
+        task_name: z.string().optional(),
+        ...create_fields,
     },
-    {
-        name: 'close_tasks',
-        description: 'Close tasks in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of tasks to close',
-                    items: {
-                        type: 'object',
-                        properties: {
-                            task_id: {
-                                type: 'string',
-                                description: 'ID of the task to close (preferred)',
-                            },
-                            task_name: {
-                                type: 'string',
-                                description: 'Name of the task to close (if ID not provided)',
-                            },
-                        },
-                        anyOf: [{ required: ['task_id'] }, { required: ['task_name'] }],
-                    },
-                },
-            },
-        },
+    method: 'POST',
+    path: '/tasks/{id}',
+    mode: 'update',
+    idField: 'task_id',
+    nameField: 'task_name',
+    findByName: (name, items) =>
+        items.find(item => item.content.toLowerCase().includes(name.toLowerCase())),
+});
+
+createBatchApiHandler({
+    name: 'close_tasks',
+    description: 'Close tasks in Todoist',
+    itemSchema: {
+        task_id: z.string().optional(),
+        task_name: z.string().optional(),
     },
-    {
-        name: 'reopen_tasks',
-        description: 'Reopen tasks in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of tasks to reopen',
-                    items: {
-                        type: 'object',
-                        properties: {
-                            task_id: {
-                                type: 'string',
-                                description: 'ID of the task to reopen (preferred)',
-                            },
-                            task_name: {
-                                type: 'string',
-                                description: 'Name of the task to reopen (if ID not provided)',
-                            },
-                        },
-                        anyOf: [{ required: ['task_id'] }, { required: ['task_name'] }],
-                    },
-                },
-            },
-        },
+    method: 'POST',
+    path: '/tasks/{id}/close',
+    mode: 'update',
+    idField: 'task_id',
+    nameField: 'task_name',
+    findByName: (name, items) =>
+        items.find(item => item.content.toLowerCase().includes(name.toLowerCase())),
+});
+
+createBatchApiHandler({
+    name: 'reopen_tasks',
+    description: 'Reopen tasks in Todoist',
+    itemSchema: {
+        task_id: z.string().optional(),
+        task_name: z.string().optional(),
     },
-    {
-        name: 'delete_tasks',
-        description: 'Delete tasks in Todoist, be careful, this action is irreversible',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of tasks to delete',
-                    items: {
-                        type: 'object',
-                        properties: {
-                            task_id: {
-                                type: 'string',
-                                description: 'ID of the task to delete (preferred)',
-                            },
-                            task_name: {
-                                type: 'string',
-                                description: 'Name of the task to delete (if ID not provided)',
-                            },
-                        },
-                        anyOf: [{ required: ['task_id'] }, { required: ['task_name'] }],
-                    },
-                },
-            },
-        },
+    method: 'POST',
+    path: '/tasks/{id}/reopen',
+    mode: 'update',
+    idField: 'task_id',
+    nameField: 'task_name',
+    findByName: (name, items) =>
+        items.find(item => item.content.toLowerCase().includes(name.toLowerCase())),
+});
+
+createBatchApiHandler({
+    name: 'delete_tasks',
+    description: 'Delete tasks from Todoist',
+    itemSchema: {
+        task_id: z.string().optional(),
+        task_name: z.string().optional(),
     },
-    {
-        name: 'move_tasks',
-        description: 'Move task in Todoist',
-        inputSchema: {
-            type: 'object',
-            required: ['items'],
-            properties: {
-                items: {
-                    type: 'array',
-                    description: 'Array of tasks to move',
-                    additionalDescription:
-                        'Set only one of: parent_id, section_id or project_id. To remove an item from a section, use only project_id with its current project value',
-                    required: ['id'],
-                    items: {
-                        type: 'object',
-                        properties: {
-                            task_id: {
-                                type: 'string',
-                                description: 'ID of the task to move (preferred)',
-                            },
-                            task_name: {
-                                type: 'string',
-                                description: 'Name of the task to move (if ID not provided)',
-                            },
-                            parent_id: {
-                                type: 'string',
-                                description: 'ID of the parent task to move the task to',
-                            },
-                            section_id: {
-                                type: 'string',
-                                description: 'ID of the section to move the task to',
-                            },
-                            project_id: {
-                                type: 'string',
-                                description: 'ID of the project to move the task to',
-                            },
-                        },
-                        anyOf: [
-                            { required: ['parent_id'] },
-                            { required: ['section_id'] },
-                            { required: ['project_id'] },
-                        ],
-                    },
-                },
-            },
-        },
+    method: 'DELETE',
+    path: '/tasks/{id}',
+    mode: 'delete',
+    idField: 'task_id',
+    nameField: 'task_name',
+    findByName: (name, items) =>
+        items.find(item => item.content.toLowerCase().includes(name.toLowerCase())),
+});
+
+createSyncApiHandler({
+    name: 'move_tasks',
+    description: 'Move tasks to a different parent or section in Todoist',
+    itemSchema: {
+        task_id: z.string().optional(),
+        task_name: z.string().optional(),
+        parent_id: z.string().optional(),
+        section_id: z.string().optional(),
+        project_id: z.string().optional(),
     },
-];
+    commandType: 'item_move',
+    idField: 'task_id',
+    nameField: 'task_name',
+    lookupPath: '/tasks',
+    findByName: (name, items) =>
+        items.find(item => item.content && item.content.toLowerCase().includes(name.toLowerCase())),
+    buildCommandArgs: (item, itemId) => {
+        const args: {
+            id: string;
+            parent_id?: string;
+            section_id?: string;
+            project_id?: string;
+        } = { id: itemId };
 
-export const TASK_HANDLERS: ToolHandlers = {
-    get_tasks_list: createApiHandler({
-        schemaShape: {
-            project_id: z.string().optional(),
-            section_id: z.string().optional(),
-            label: z.string().optional(),
-            filter: z.string().optional(),
-            ids: z.string().optional(),
-            limit: z.number().optional(),
-        },
-        method: 'GET',
-        path: '/tasks',
-        errorPrefix: 'Failed to get tasks',
-        processResult: (results, args) => {
-            let filteredTasks = results;
-            filteredTasks = filteredTasks.slice(0, args.limit || 50);
-            return filteredTasks;
-        },
-    }),
+        // Only one destination option
+        if (item.parent_id) args.parent_id = item.parent_id;
+        else if (item.section_id) args.section_id = item.section_id;
+        else if (item.project_id) args.project_id = item.project_id;
 
-    create_tasks: createBatchApiHandler({
-        itemSchema: {
-            content: z.string(),
-            description: z.string().optional(),
-            project_id: z.string().optional(),
-            section_id: z.string().optional(),
-            parent_id: z.string().optional(),
-            order: z.number().int().optional(),
-            labels: z.array(z.string()).optional(),
-            priority: z.number().int().min(1).max(4).optional(),
-            due_string: z.string().optional(),
-            due_date: z.string().optional(),
-            due_datetime: z.string().optional(),
-            due_lang: z.string().optional(),
-            assignee_id: z.string().optional(),
-            duration: z.number().int().positive().optional(),
-            duration_unit: z.enum(['minute', 'day']).optional(),
-        },
-        method: 'POST',
-        path: '/tasks',
-        errorPrefix: 'Failed to create tasks',
-        mode: 'create',
-    }),
+        return args;
+    },
+    validateItem: item => {
+        // Ensure exactly one destination is specified
+        const destinationCount = [item.parent_id, item.section_id, item.project_id].filter(
+            Boolean
+        ).length;
 
-    get_tasks: createBatchApiHandler({
-        itemSchema: {
-            task_id: z.string().optional(),
-            task_name: z.string().optional(),
-        },
-        method: 'GET',
-        path: '/tasks/{id}',
-        errorPrefix: 'Failed to get task',
-        mode: 'read',
-        idField: 'task_id',
-        nameField: 'task_name',
-        findByName: (name, items) =>
-            items.find(
-                item => item.content && item.content.toLowerCase().includes(name.toLowerCase())
-            ),
-    }),
+        if (destinationCount !== 1) {
+            return {
+                valid: false,
+                error: 'Exactly one of parent_id, section_id, or project_id must be provided',
+            };
+        }
 
-    update_tasks: createBatchApiHandler({
-        itemSchema: {
-            task_id: z.string().optional(),
-            task_name: z.string().optional(),
-            content: z.string().optional(),
-            description: z.string().optional(),
-            labels: z.array(z.string()).optional(),
-            priority: z.number().int().min(1).max(4).optional(),
-            due_string: z.string().optional(),
-            due_date: z.string().optional(),
-            due_datetime: z.string().optional(),
-            due_lang: z.string().optional(),
-            assignee_id: z.string().optional(),
-            duration: z.number().int().positive().optional(),
-            duration_unit: z.enum(['minute', 'day']).optional(),
-        },
-        method: 'POST',
-        path: '/tasks/{id}',
-        errorPrefix: 'Failed to update tasks',
-        mode: 'update',
-        idField: 'task_id',
-        nameField: 'task_name',
-        findByName: (name, items) =>
-            items.find(
-                item => item.content && item.content.toLowerCase().includes(name.toLowerCase())
-            ),
-    }),
-
-    close_tasks: createBatchApiHandler({
-        itemSchema: {
-            task_id: z.string().optional(),
-            task_name: z.string().optional(),
-        },
-        method: 'POST',
-        basePath: '/tasks',
-        pathSuffix: '/{id}/close',
-        errorPrefix: 'Failed to close tasks',
-        mode: 'update',
-        idField: 'task_id',
-        nameField: 'task_name',
-        findByName: (name, items) =>
-            items.find(
-                item => item.content && item.content.toLowerCase().includes(name.toLowerCase())
-            ),
-    }),
-
-    reopen_tasks: createBatchApiHandler({
-        itemSchema: {
-            task_id: z.string().optional(),
-            task_name: z.string().optional(),
-        },
-        method: 'POST',
-        basePath: '/tasks',
-        pathSuffix: '/{id}/reopen',
-        errorPrefix: 'Failed to reopen tasks',
-        mode: 'update',
-        idField: 'task_id',
-        nameField: 'task_name',
-        findByName: (name, items) =>
-            items.find(
-                item => item.content && item.content.toLowerCase().includes(name.toLowerCase())
-            ),
-    }),
-
-    delete_tasks: createBatchApiHandler({
-        itemSchema: {
-            task_id: z.string().optional(),
-            task_name: z.string().optional(),
-        },
-        method: 'DELETE',
-        path: '/tasks/{id}',
-        errorPrefix: 'Failed to delete tasks',
-        mode: 'delete',
-        idField: 'task_id',
-        nameField: 'task_name',
-        findByName: (name, items) =>
-            items.find(
-                item => item.content && item.content.toLowerCase().includes(name.toLowerCase())
-            ),
-    }),
-
-    move_tasks: createSyncApiHandler({
-        itemSchema: {
-            task_id: z.string().optional(),
-            task_name: z.string().optional(),
-            parent_id: z.string().optional(),
-            section_id: z.string().optional(),
-            project_id: z.string().optional(),
-        },
-        commandType: 'item_move',
-        errorPrefix: 'Failed to move tasks',
-        idField: 'task_id',
-        nameField: 'task_name',
-        lookupPath: '/tasks',
-        findByName: (name, items) =>
-            items.find(
-                item => item.content && item.content.toLowerCase().includes(name.toLowerCase())
-            ),
-        buildCommandArgs: (item, itemId) => {
-            const args: {
-                id: string;
-                parent_id?: string;
-                section_id?: string;
-                project_id?: string;
-            } = { id: itemId };
-
-            // Only one destination option
-            if (item.parent_id) args.parent_id = item.parent_id;
-            else if (item.section_id) args.section_id = item.section_id;
-            else if (item.project_id) args.project_id = item.project_id;
-
-            return args;
-        },
-        validateItem: item => {
-            // Ensure exactly one destination is specified
-            const destinationCount = [item.parent_id, item.section_id, item.project_id].filter(
-                Boolean
-            ).length;
-
-            if (destinationCount !== 1) {
-                return {
-                    valid: false,
-                    error: 'Exactly one of parent_id, section_id, or project_id must be provided',
-                };
-            }
-
-            return { valid: true };
-        },
-    }),
-};
+        return { valid: true };
+    },
+});

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -7,29 +7,62 @@ import {
 
 /// Common fields for create and update tasks
 const create_fields = {
-    content: z.string(),
-    description: z.string().optional(),
+    content: z
+        .string()
+        .describe('Task title (brief). May contain markdown-formatted text and hyperlinks'),
+    description: z
+        .string()
+        .optional()
+        .describe('Description (detailed). May contain markdown-formatted text and hyperlinks'),
     labels: z.array(z.string()).optional(),
-    priority: z.number().int().min(1).max(4).optional(),
-    due_string: z.string().optional(),
-    due_date: z.string().optional(),
-    due_datetime: z.string().optional(),
-    due_lang: z.string().optional(),
-    assignee_id: z.string().optional(),
-    duration: z.number().int().positive().optional(),
-    duration_unit: z.enum(['minute', 'day']).optional(),
+    priority: z.number().int().min(1).max(4).optional().describe('From 1 (urgent) to 4 (normal)'),
+    due_string: z
+        .string()
+        .optional()
+        .describe(
+            'Human defined task due date (ex.: "next Monday", "Tomorrow"). Value is set using local (not UTC) time, if not in english provided, due_lang should be set to the language of the string'
+        ),
+    due_date: z.string().optional().describe('Date in YYYY-MM-DD format relative to user timezone'),
+    due_datetime: z.string().optional().describe('Specific date and time in RFC3339 format in UTC'),
+    due_lang: z
+        .string()
+        .optional()
+        .describe('2-letter code specifying language in case due_string is not written in english'),
+    assignee_id: z
+        .string()
+        .optional()
+        .describe('The responsible user ID (only applies to shared tasks)'),
+    duration: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+            'A positive (greater than zero) integer for the amount of duration_unit the task will take'
+        ),
+    duration_unit: z
+        .enum(['minute', 'day'])
+        .optional()
+        .describe(
+            'The unit of time that the duration field represents. Must be either minute or day'
+        ),
 };
 
 createApiHandler({
     name: 'get_tasks_list',
     description: 'Get tasks list from Todoist',
     schemaShape: {
-        project_id: z.string().optional(),
-        section_id: z.string().optional(),
-        label: z.string().optional(),
-        filter: z.string().optional(),
-        ids: z.string().optional(),
-        limit: z.number().optional(),
+        project_id: z.string().optional().describe('Filter by project'),
+        section_id: z.string().optional().describe('Filter by section'),
+        label: z.string().optional().describe('Filter by label'),
+        filter: z
+            .string()
+            .optional()
+            .describe(
+                'Natural language english filter like "search: keyword", "today", "date before: +4 hours", "date after: May 5", "no date", "no time", "overdue", "7 days & @waiting", "created before: -365 days", "assigned to: person", "added by: me", "#Project & !assigned", "subtask", "!subtask", "P1 | P2", "today & @email", "@work | @office", "(today | overdue) & #Work", "all & 7 days", "!assigned", "Today & !#Work"'
+            ),
+        ids: z.string().optional().describe('Comma-separated list of task IDs'),
+        limit: z.number().optional().default(50),
     },
     method: 'GET',
     path: '/tasks',
@@ -40,7 +73,10 @@ createBatchApiHandler({
     description: 'Create new tasks in Todoist',
     itemSchema: {
         ...create_fields,
-        project_id: z.string().optional(),
+        project_id: z
+            .string()
+            .optional()
+            .describe("Task project ID. If not set, task is put to user's Inbox"),
         section_id: z.string().optional(),
         parent_id: z.string().optional(),
     },
@@ -53,8 +89,11 @@ createBatchApiHandler({
     name: 'get_tasks',
     description: 'Get tasks from Todoist',
     itemSchema: {
-        task_id: z.string().optional(),
-        task_name: z.string().optional(),
+        task_id: z.string().optional().describe('ID of the task to retrieve (preferred)'),
+        task_name: z
+            .string()
+            .optional()
+            .describe('Name of the task to retrieve (if ID not provided)'),
     },
     method: 'GET',
     path: '/tasks/{id}',
@@ -63,6 +102,15 @@ createBatchApiHandler({
     nameField: 'task_name',
     findByName: (name, items) =>
         items.find(item => item.content.toLowerCase().includes(name.toLowerCase())),
+    validateItem: item => {
+        if (!item.task_id && !item.task_name) {
+            return {
+                valid: false,
+                error: 'Either task_id or task_name must be provided',
+            };
+        }
+        return { valid: true };
+    },
 });
 
 createBatchApiHandler({
@@ -80,6 +128,15 @@ createBatchApiHandler({
     nameField: 'task_name',
     findByName: (name, items) =>
         items.find(item => item.content.toLowerCase().includes(name.toLowerCase())),
+    validateItem: item => {
+        if (!item.task_id && !item.task_name) {
+            return {
+                valid: false,
+                error: 'Either task_id or task_name must be provided',
+            };
+        }
+        return { valid: true };
+    },
 });
 
 createBatchApiHandler({
@@ -96,6 +153,15 @@ createBatchApiHandler({
     nameField: 'task_name',
     findByName: (name, items) =>
         items.find(item => item.content.toLowerCase().includes(name.toLowerCase())),
+    validateItem: item => {
+        if (!item.task_id && !item.task_name) {
+            return {
+                valid: false,
+                error: 'Either task_id or task_name must be provided',
+            };
+        }
+        return { valid: true };
+    },
 });
 
 createBatchApiHandler({
@@ -112,6 +178,16 @@ createBatchApiHandler({
     nameField: 'task_name',
     findByName: (name, items) =>
         items.find(item => item.content.toLowerCase().includes(name.toLowerCase())),
+    validateItem: item => {
+        if (!item.task_id && !item.task_name) {
+            return {
+                valid: false,
+                error: 'Either task_id or task_name must be provided',
+            };
+        }
+
+        return { valid: true };
+    },
 });
 
 createBatchApiHandler({
@@ -128,6 +204,16 @@ createBatchApiHandler({
     nameField: 'task_name',
     findByName: (name, items) =>
         items.find(item => item.content.toLowerCase().includes(name.toLowerCase())),
+    validateItem: item => {
+        if (!item.task_id && !item.task_name) {
+            return {
+                valid: false,
+                error: 'Either task_id or task_name must be provided',
+            };
+        }
+
+        return { valid: true };
+    },
 });
 
 createSyncApiHandler({

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -1,18 +1,10 @@
-import { Tool } from '@modelcontextprotocol/sdk/types.js';
-import { ToolHandlers, ToolResult } from '../utils/types.js';
+import { createHandler } from '../utils/handlers.js';
 
-export const UTILS_TOOLS: Tool[] = [
-    {
-        name: 'utils_get_colors',
-        description: 'Get available colors for projects, labels, filters in Todoist',
-        inputSchema: {
-            type: 'object',
-        },
-    },
-];
-
-export const UTILS_HANDLERS: ToolHandlers = {
-    utils_get_colors: async (): Promise<ToolResult> => {
+createHandler(
+    'utils_get_colors',
+    'Get available colors for projects, labels, filters in Todoist',
+    {},
+    async () => {
         const colors = [
             { id: 30, name: 'berry_red', hex: '#B8255F' },
             { id: 31, name: 'red', hex: '#DC4C3E' },
@@ -26,13 +18,6 @@ export const UTILS_HANDLERS: ToolHandlers = {
             { id: 39, name: 'sky_blue', hex: '#319DC0' },
         ];
 
-        return {
-            content: [
-                {
-                    type: 'text',
-                    text: `${colors.map(color => `ID: ${color.id}, ${color.name}, (${color.hex})`).join('. ')}`,
-                },
-            ],
-        };
-    },
-};
+        return colors.map(color => `ID: ${color.id}, ${color.name}, (${color.hex})`).join('. ');
+    }
+);

--- a/src/utils/TodoistClient.ts
+++ b/src/utils/TodoistClient.ts
@@ -2,6 +2,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import { log } from './helpers.js';
+import { SyncCommand } from './types.js';
 
 const API_BASE_URL = 'https://api.todoist.com/rest/v2';
 const API_SYNC_BASE_URL = 'https://api.todoist.com/sync/v9';
@@ -115,13 +116,7 @@ export class TodoistClient {
      * @param commands - Array of command objects to execute
      * @returns API response data
      */
-    async sync(
-        commands: Array<{
-            type: string;
-            uuid: string;
-            args: Record<string, any>;
-        }>
-    ): Promise<any> {
+    async sync(commands: Array<SyncCommand>): Promise<any> {
         const url = `${API_SYNC_BASE_URL}/sync`;
 
         log(`Making SYNC request to: ${url} with commands:`, JSON.stringify(commands, null, 2));

--- a/src/utils/handlers.ts
+++ b/src/utils/handlers.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { z } from 'zod';
-import { log, todoistApi } from './helpers.js';
+import { log } from './helpers.js';
+import { todoistApi } from "../clients.js";
 import { ToolResult } from './types.js';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -13,6 +13,5 @@ export const config = {
     API_KEY: process.env.API_KEY ?? '',
 };
 
-export const todoistApi = new TodoistClient(config.API_KEY);
 
 export { version } from './version.js';

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,3 @@
-import { TodoistClient } from './TodoistClient.js';
-
 const debug = true;
 
 export function log(...args: unknown[]) {
@@ -12,6 +10,5 @@ export function log(...args: unknown[]) {
 export const config = {
     API_KEY: process.env.API_KEY ?? '',
 };
-
 
 export { version } from './version.js';

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -14,12 +14,3 @@ export type ToolResult = {
     content: Array<{ type: string; text: string }>;
     isError?: boolean;
 };
-
-export type PromptResult = {
-    messages: Array<{ role: string; content: { type: string; text: string } }>;
-};
-
-export type PromptHandlers = Record<
-    string,
-    (request: z.infer<typeof GetPromptRequestSchema>) => Promise<PromptResult>
->;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,8 +1,4 @@
-import {
-    CallToolRequestSchema,
-    GetPromptRequestSchema,
-    Result,
-} from '@modelcontextprotocol/sdk/types.js';
+import { CallToolRequestSchema, Result } from '@modelcontextprotocol/sdk/types.js';
 import z from 'zod';
 
 export type ToolHandlers = Record<
@@ -13,4 +9,11 @@ export type ToolHandlers = Record<
 export type ToolResult = {
     content: Array<{ type: string; text: string }>;
     isError?: boolean;
+};
+
+export type SyncCommand = {
+    type: string;
+    uuid: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    args: Record<string, any>;
 };


### PR DESCRIPTION
## Summary of Changes
This pull request focuses on modernizing the Todoist MCP server by replacing the original `Server` implementation with `MCPServer` from the `@modelcontextprotocol/sdk`. This change streamlines the code, leveraging the new server features and simplifying request handling. Additionally, the pull request updates the handlers for tools and prompts to align with the new `MCPServer` setup, enhancing the server's functionality and maintainability. The SDK dependency is also updated from version 1.0.0 to 1.1.1.

### Highlights
* **Server Implementation**: Replaces the `Server` with `MCPServer` for improved server management and capabilities.
* **Handler Updates**: Updates tool and prompt handlers to be compatible with the new `MCPServer` implementation.
* **Dependency Update**: Updates `@modelcontextprotocol/sdk` from version 1.0.0 to 1.1.1.
* **Tool and Prompt Definitions**: The pull request refactors the way tools and prompts are defined, using the `server.tool` and `server.prompt` methods to register them directly with the `MCPServer` instance. This approach simplifies the code and makes it more declarative.

### Changelog
<details>
<summary>Click here to see the changelog</summary>

* **package-lock.json**
  * Updates `@modelcontextprotocol/sdk` dependency from version 1.0.0 to 1.1.1.
* **package.json**
  * Updates `@modelcontextprotocol/sdk` dependency from version 1.0.0 to 1.1.1.
* **src/clients.ts**
  * Introduces `McpServer` instance for the Todoist MCP server.
  * Defines server name, version, and instructions for interacting with the Todoist API.
  * Exports the `todoistApi` client and `server` instance.
* **src/index.ts**
  * Removes the original `Server` import and request handling logic.
  * Imports the `server` instance from `src/clients.ts`.
  * Removes the explicit request handlers for tools and prompts, relying on the `MCPServer`'s built-in routing.
* **src/prompts.ts**
  * Removes the explicit exports for `ALL_PROMPTS` and `ALL_PROMPT_HANDLERS`.
  * Changes the import to a side-effect import: `import './prompts/projects.js';`
* **src/prompts/projects.ts**
  * Imports `server` from `src/clients.ts`.
  * Registers the `projects_list` prompt directly with the `server` instance using `server.prompt`.
  * Removes the explicit `PROJECT_LIST_RPOMPT_HANDLER` export.
* **src/tools.ts**
  * Removes the explicit exports for `ALL_TOOLS` and `ALL_HANDLERS`.
  * Changes the imports to side-effect imports: `import './tools/comments.js';` etc.
* **src/tools/comments.ts**
  * Removes the explicit `COMMENTS_TOOLS` and `COMMENT_HANDLERS` exports.
  * Uses `createApiHandler` and `createBatchApiHandler` to register the comment-related tools directly with the `server` instance.
* **src/tools/labels.ts**
  * Removes the explicit `LABELS_TOOLS` and `LABEL_HANDLERS` exports.
  * Uses `createApiHandler` and `createBatchApiHandler` to register the label-related tools directly with the `server` instance.
* **src/tools/projects.ts**
  * Removes the explicit `PROJECT_TOOLS` and `PROJECT_HANDLERS` exports.
  * Uses `createApiHandler`, `createBatchApiHandler`, and `createSyncApiHandler` to register the project-related tools directly with the `server` instance.
* **src/tools/sections.ts**
  * Removes the explicit `SECTION_TOOLS` and `SECTION_HANDLERS` exports.
  * Uses `createApiHandler` and `createBatchApiHandler` to register the section-related tools directly with the `server` instance.
* **src/tools/tasks.ts**
  * Removes the explicit `TASKS_TOOLS` and `TASK_HANDLERS` exports.
  * Uses `createApiHandler`, `createBatchApiHandler`, and `createSyncApiHandler` to register the task-related tools directly with the `server` instance.
* **src/tools/utils.ts**
  * Removes the explicit `UTILS_TOOLS` and `UTILS_HANDLERS` exports.
  * Uses `createHandler` to register the `utils_get_colors` tool directly with the `server` instance.
* **src/utils/TodoistClient.ts**
  * Imports `SyncCommand` type
  * Updates the `sync` method to use the `SyncCommand` type for the `commands` parameter.
* **src/utils/handlers.ts**
  * Imports `ToolCallback` from `@modelcontextprotocol/sdk/server/mcp.js`.
  * Imports `server` and `todoistApi` from `../clients.js`.
  * Updates `createHandler` to register tools directly with the `server` instance using `server.tool`.
  * Updates `createApiHandler`, `createBatchApiHandler`, and `createSyncApiHandler` to use the new `createHandler` and register tools/prompts with the `server` instance.
  * Adds validation for `idField` and `nameField` in `createBatchApiHandler`.
  * Removes `errorPrefix` from handler functions.
  * Adds `validateItem` option to `createBatchApiHandler` and `createSyncApiHandler` to allow custom validation logic for each item in a batch.
* **src/utils/helpers.ts**
  * Removes the export of `todoistApi` as it is now imported directly where needed.
* **src/utils/types.ts**
  * Removes `GetPromptRequestSchema` import and `PromptHandlers` type.
  * Removes `PromptResult` type.
  * Adds `SyncCommand` type.

</details>