### PR TITLE
Add support for deadline_date and deadline_lang parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "todoist-mcp",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "todoist-mcp",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.1.1",

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -24,7 +24,7 @@ const create_fields = {
         .describe(
             'Human defined task due date (ex.: "next Monday", "Tomorrow"). Value is set using local (not UTC) time, if not in english provided, due_lang should be set to the language of the string'
         ),
-    due_date: z.string().optional().describe('Date in YYYY-MM-DD format relative to user timezone'),
+    due_date: z.string().optional().describe('Due date in YYYY-MM-DD format relative to user timezone (when you plan to work on task)'),
     due_datetime: z.string().optional().describe('Specific date and time in RFC3339 format in UTC'),
     due_lang: z
         .string()
@@ -51,7 +51,7 @@ const create_fields = {
     deadline_date: z
         .string()
         .optional()
-        .describe('Specific date in YYYY-MM-DD format relative to user timezone'),
+        .describe('Deadline date in YYYY-MM-DD format relative to user timezone (fixed date when task must be completed, for tasks with external consequences)'),
     deadline_lang: z
         .string()
         .optional()

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -48,6 +48,14 @@ const create_fields = {
         .describe(
             'The unit of time that the duration field represents. Must be either minute or day'
         ),
+    deadline_date: z
+        .string()
+        .optional()
+        .describe('Specific date in YYYY-MM-DD format relative to user timezone'),
+    deadline_lang: z
+        .string()
+        .optional()
+        .describe('2-letter code specifying language of deadline'),
 };
 
 createApiHandler({


### PR DESCRIPTION
This PR adds support for two new optional parameters to the Todoist tasks API:
• deadline_date: Specific date in YYYY-MM-DD format relative to user timezone
• deadline_lang: 2-letter code specifying language of deadline

These parameters enhance the task creation functionality by allowing users to set specific deadline dates
with language localization.